### PR TITLE
installation: fix missing Flask-Testing package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ history = open('CHANGES.rst').read()
 
 requirements = [
     'Flask>=0.10.1',
+    'Flask-Testing>=0.4.1',
     'six>=1.7.2',
     'invenio-base>=0.2.1',
     'invenio-ext>=0.1.0',


### PR DESCRIPTION
- FIX Adds missing Flask-Testing>=0.4.1 dependency.

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
