### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Testing.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-testing
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/invenio_testing/translations/de/LC_MESSAGES/messages.po
+++ b/invenio_testing/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-testing 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-21 18:55+0200\n"
 "PO-Revision-Date: 2015-09-21 18:55+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_testing/translations/es/LC_MESSAGES/messages.po
+++ b/invenio_testing/translations/es/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-testing 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-21 18:55+0200\n"
 "PO-Revision-Date: 2015-09-21 18:55+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_testing/translations/fr/LC_MESSAGES/messages.po
+++ b/invenio_testing/translations/fr/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-testing 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-21 18:55+0200\n"
 "PO-Revision-Date: 2015-09-21 18:55+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_testing/translations/invenio.pot
+++ b/invenio_testing/translations/invenio.pot
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-testing 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-21 18:55+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/invenio_testing/translations/it/LC_MESSAGES/messages.po
+++ b/invenio_testing/translations/it/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-testing 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-09-21 18:55+0200\n"
 "PO-Revision-Date: 2015-09-21 18:55+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ directory = invenio_testing/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_testing/translations/invenio.pot
 

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     keywords='invenio testing',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-testing',
     packages=[
         'invenio_testing',


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
